### PR TITLE
add .editorconfig to help maintaing code style consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs.
+# Requires EditorConfig JetBrains Plugin - http://github.com/editorconfig/editorconfig-jetbrains
+
+# Set this file as the topmost .editorconfig
+# (multiple files can be used, and are applied starting from current document location)
+root = true
+
+# Use bracketed regexp to target specific file types or file locations
+[*]
+
+# Use hard or soft tabs ["tab", "space"]
+indent_style = space
+
+# Size of a single indent [an integer, "tab"]
+indent_size = 4
+
+# Line breaks representation ["lf", "cr", "crlf"]
+end_of_line = lf
+
+# ["latin1", "utf-8", "utf-16be", "utf-16le"]
+charset = utf-8
+
+# Remove any whitespace characters preceding newline characters ["true", "false"]
+trim_trailing_whitespace = true
+
+# Ensure file ends with a newline when saving ["true", "false"]
+insert_final_newline = true
+
+[Makefile]
+
+indent_style = tab


### PR DESCRIPTION
This file contains my opinionated config on how I write `sh` scripts, etc. Feel free to let me know if you want it changed or follow different conventions. The main goal for me is to keep consistency among files and avoid some merge conflicts due to incosistent whitespace etc. Conventions we would keep (tabs vs spaces) are secondary issue to me, so I won't fight for 2 vs 4 spaces etc. :D 