### PR TITLE
remove .hgignore as it is unused

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,3 +1,0 @@
-syntax: glob
-
-media


### PR DESCRIPTION
Please let me know if `.hgignore` is actually unused. It seems to be some kind of leftover in a git repo.