### PR TITLE
Makefile, build configuration variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.DEFAULT_GOAL=all
+
+IMG_URL?=https://serverop.de/crux/crux-3.5/iso/crux-3.5.iso
+IMG_FILENAME?=crux-3.5.iso
+CRUX_VERSION?=3.5
+
+# aarch64)
+#   IMG_URL="http://resources.crux-arm.nu/releases/${VERSION}/crux-arm-rootfs-${VERSION}-aarch64.tar.xz"
+#   IMG_FILENAME="crux-arm-rootfs-${VERSION}-aarch64.tar.xz"
+
+x86_64.build:
+	IMG_FILENAME=$(IMG_FILENAME) IMG_URL=$(IMG_URL) ./release build $(CRUX_VERSION)
+
+x86_64.commit: x86_64.build
+	./release commit $(CRUX_VERSION)
+
+x86_64.test: x86_64.commit
+	./release test $(CRUX_VERSION)
+
+x86_64.push: x86_64.test
+	./release push $(CRUX_VERSION)
+
+x86_64: x86_64.test
+
+all: x86_64

--- a/build/aarch64/buildenv/build
+++ b/build/aarch64/buildenv/build
@@ -9,8 +9,8 @@ die () {
 
 download()
 {
-    echo "Downloading ${URL} ..."
-    curl -q ${URL} -o rootfs.tar.xz
+    echo "Downloading ${IMG_URL} ..."
+    curl -q ${IMG_URL} -o rootfs.tar.xz
 }
 
 repackage()

--- a/build/x86_64/buildenv/build
+++ b/build/x86_64/buildenv/build
@@ -9,26 +9,19 @@ die () {
 
 download()
 {
-    echo "Downloading ${URL} ..."
-    curl -q ${URL} -o $(basename ${URL})
+    echo "Downloading ${IMG_URL} ..."
+    curl -q ${IMG_URL} -o $(basename ${IMG_URL})
 }
 
 mkrootfsfromiso()
 {
-    ISO=$(basename ${URL})
-
     # Make sure the downloaded file exists
-    if [ ! -e ${ISO} ]; then
-	echo "${ISO} doesn't exist"
-    fi
-
-    # Ensure the downloaded file is an ISO file
-    if ! ls | grep *.iso$ > /dev/null; then
-	echo "No ISO found"
+    if [ ! -e ${IMG_FILENAME} ]; then
+	echo "${IMG_FILENAME} doesn't exist"
     fi
 
     # Mount the ISO
-    mount -o ro,loop ${ISO} ${CRUX}
+    mount -r -o loop ${IMG_FILENAME} ${CRUX}
 
     # Extract pkgutils
     tar -C ${TMP} -xf ${CRUX}/tools/pkgutils#*.pkg.tar.gz

--- a/release
+++ b/release
@@ -47,15 +47,6 @@ fetchversion()
 
 buildrootfs()
 {
-	case "${ARCH}" in
-		x86_64)
-			URL="http://ftp.morpheus.net/pub/linux/crux/crux-${VERSION}/iso/crux-${VERSION}.iso"
-			;;
-	aarch64)
-			URL="http://resources.crux-arm.nu/releases/${VERSION}/crux-arm-rootfs-${VERSION}-aarch64.tar.xz"
-			;;
-	esac
-
 	if docker ps -a | grep -q cruxbuild; then
 		docker rm -f cruxbuild > /dev/null
 	fi
@@ -65,7 +56,8 @@ buildrootfs()
 	docker run \
 		-i -t --privileged \
 		--name cruxbuild \
-		-e URL=${URL} \
+		-e IMG_FILENAME=${IMG_FILENAME} \
+		-e IMG_URL=${IMG_URL} \
 		-e VERSION=${VERSION} \
 		cruxbuild
 


### PR DESCRIPTION
This PR contains:

1. `release` script uses env variables to load ISO URL instead of hardcoded values and guessing version / filename by analyzing URL. It makes it easier to use with CI as it is possible to switch mirrors with ENV variables, also it comes in handy while testing the project locally. It is possible to start a local http-server that serves crux.iso and let build script 'download' it from localhost, which speed everything up and reduces network traffic.
2. Makefile to make sure it's easy to execute build steps in the right order. Makefiles makes use of those extra ENV variables.